### PR TITLE
Correct quickmail.h include

### DIFF
--- a/src/ESPMail.h
+++ b/src/ESPMail.h
@@ -2,7 +2,7 @@
 
 /*
 ESPMail - Library for sending emails based on libquickmail.
-Created by Grzegorz Leúniak, June 28, 2017.
+Created by Grzegorz Le≈ìniak, June 28, 2017.
 
 ESPMail is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ along with ESPMail.  If not, see <http://www.gnu.org/licenses/>.
 #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_SAM)
 #include "Arduino.h"
 #include <Client.h>
-#include "libquickmail\quickmail.h"
+#include "libquickmail/quickmail.h"
 #else
 #error Only Arduino MKR1000, Yun, Uno/Mega/Due with either WiFi101 or Ethernet shield. ESP8266 also supported.
 #endif


### PR DESCRIPTION
One of the includes used a backslash for includes, causing compiling errors. This quick fix will get everything in order.